### PR TITLE
DeepSeek Checkbox Error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+
+# Using-Direktiven organisieren
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false

--- a/ChatGPTWindowControl.xaml
+++ b/ChatGPTWindowControl.xaml
@@ -87,7 +87,7 @@
         </Grid.ColumnDefinitions>
 
         <!-- Context Menu Button -->
-        <Button Grid.Row="0" Grid.Column="3" Content="▼" Height="30" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}">
+        <Button Grid.Row="2" Grid.Column="3" Content="▼" Height="30" Width="30" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}">
             <Button.ContextMenu>
                 <ContextMenu x:Name="CodeActionsContextMenu" FontSize="15">
                 </ContextMenu>
@@ -112,7 +112,7 @@
         <Button Grid.Row="0" Grid.Column="1" Name="btnFixCodeInAI" Content="Fix Code in GPT ➡️" Click="OnSendCodeButtonClick" Tag="Fix {languageCode} code below:" Height="30" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Transfer selected code from GPT to VS.NET"/>
 
         <!-- Improve Code in GPT Button -->
-        <Button Grid.Row="0" Grid.Column="2" Name="btnImproveCodeInAI" Content="Improve Code in GPT ➡️" Click="OnSendCodeButtonClick" Tag="Improve {languageCode} code below:" Height="30" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Refactor selected code from VS.NET in GPT" />
+        <Button Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2" Name="btnImproveCodeInAI" Content="Improve Code in GPT ➡️" Click="OnSendCodeButtonClick" Tag="Improve {languageCode} code below:" Height="30" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Refactor selected code from VS.NET in GPT" />
 
         <!-- GPT to VS.NET Button -->
         <Button Grid.Row="1" Grid.Column="0" Name="btnAIToVSNET" Content="⬅️ GPT to VS.NET" Click="OnReceiveCodeButtonClick" Height="30" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Transfer selected code from GPT to VS.NET"/>
@@ -130,8 +130,8 @@
         <Button Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="1" Name="btnContinueCode" Content="Continue Code ⏩" Click="OnContinueCodeButtonClick" Height="30" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Continue code generation"/>
 
         <!-- Enable Copy Code Checkbox -->
-        <Border Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" Background="#343541" CornerRadius="4">
-            <CheckBox Style="{StaticResource CustomCheckBoxStyle}" HorizontalAlignment="Right" Name="EnableCopyCodeCheckBox" Click="EnableCopyCodeCheckBox_Click" IsChecked="True" ToolTip="Enable sending code from GPT to VS.NET when Copy code button is clicked in GPT" />
+        <Border Grid.Row="2" Grid.Column="2" Background="#343541">
+            <CheckBox Style="{StaticResource CustomCheckBoxStyle}" HorizontalAlignment="Center" Name="EnableCopyCodeCheckBox" Click="EnableCopyCodeCheckBox_Click" IsChecked="True" ToolTip="Enable sending code from GPT to VS.NET when Copy code button is clicked in GPT" />
         </Border>
 
         <!-- WebView2 Control -->

--- a/ChatGPTWindowControl.xaml.cs
+++ b/ChatGPTWindowControl.xaml.cs
@@ -10,27 +10,26 @@
  *           
  * *******************************************************************************************************************/
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Windows;
-using System.Diagnostics;
-using System.Windows.Input;
-using System.Threading.Tasks;
-using System.Windows.Controls;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-
 using EnvDTE;
 using EnvDTE80;
-using Newtonsoft.Json;
-using Microsoft.Win32;
-using Microsoft.Web.WebView2.Core;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Win32;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Threading;
 using Window = System.Windows.Window;
-using Microsoft.VisualStudio.Shell.Interop;
 
 namespace ChatGPTExtension
 {
@@ -1052,6 +1051,7 @@ namespace ChatGPTExtension
                 useGptMenuItem.IsChecked = true;
                 useGeminiMenuItem.IsChecked = false;
                 useClaudeMenuItem.IsChecked = false;
+                useDeepSeekMenuItem.IsChecked = false;
                 reloadMenuItem.Header = "Reload Chat GPT...";
                 _parentToolWindow.Caption = "Chat GPT Extension";
                 UpdateButtonContentAndTooltip();
@@ -1064,9 +1064,10 @@ namespace ChatGPTExtension
             useGeminiMenuItem.Click += (sender, e) =>
             {
                 _aiModelType = AIModelType.Gemini;
-                useGeminiMenuItem.IsChecked = true;
                 useGptMenuItem.IsChecked = false;
+                useGeminiMenuItem.IsChecked = true;
                 useClaudeMenuItem.IsChecked = false;
+                useDeepSeekMenuItem.IsChecked = false;
                 reloadMenuItem.Header = "Reload Gemini...";
                 _parentToolWindow.Caption = "Gemini Extension";
                 UpdateButtonContentAndTooltip();
@@ -1079,9 +1080,10 @@ namespace ChatGPTExtension
             useClaudeMenuItem.Click += (sender, e) =>
             {
                 _aiModelType = AIModelType.Claude;
-                useGeminiMenuItem.IsChecked = false;
                 useGptMenuItem.IsChecked = false;
+                useGeminiMenuItem.IsChecked = false;
                 useClaudeMenuItem.IsChecked = true;
+                useDeepSeekMenuItem.IsChecked = false;
                 reloadMenuItem.Header = "Reload Claude...";
                 _parentToolWindow.Caption = "Claude Extension";
                 UpdateButtonContentAndTooltip();


### PR DESCRIPTION
Fix: If DeepSeek was enabled and then switched to GPT, Gemini, or Claude, the DeepSeek checkbox would still be selected.

