### PR TITLE
UI update for button labels

### DIFF
--- a/AIConfigurations/GPTConfiguration.cs
+++ b/AIConfigurations/GPTConfiguration.cs
@@ -89,30 +89,36 @@ namespace ChatGPTExtension
         public string GetScrollToBottomScript()
         {
             return @"
-        var button = document.querySelector('button.absolute[class*=""bottom-5""] svg.icon-md');
-        if (button) {
-            button.parentElement.click();
-        }";
+            var button = document.querySelector('button.cursor-pointer.absolute.z-10.bottom-\\[calc\\(var\\(--composer-overlap-px\\)\\+--spacing\\(6\\)\\)\\]');
+            if (button) {
+                button.click();
+            }";
         }
 
-        public string GetAttachFileButtonClickScript()
+
+        public string GetFileInputClickScript()
         {
-            return @"document
-                  .querySelector('button svg path[d=""M12 3C12.5523 3 13 3.44772 13 4L13 11H20C20.5523 11 21 11.4477 21 12C21 12.5523 20.5523 13 20 13L13 13L13 20C13 20.5523 12.5523 21 12 21C11.4477 21 11 20.5523 11 20L11 13L4 13C3.44772 13 3 12.5523 3 12C3 11.4477 3.44772 11 4 11L11 11L11 4C11 3.44772 11.4477 3 12 3Z""]')
-                  ?.closest('button')
-                  ?.click();";
+            return @"
+            var input = document.querySelector('input[type=""file""][multiple].hidden');
+            if (input) {
+                input.click();
+            }";
         }
 
         public string GetAttachFileMenuItemClickScript()
         {
             return @"
-        setTimeout(() => {
-            const menuItems = document.querySelectorAll('div[role=""menuitem""]');
-            if (menuItems?.length > 0) {
-                menuItems[menuItems.length - 1]?.click();
-            }
-        }, 800);";
+setTimeout(() => {
+    const menuItems = document.querySelectorAll('div[role=""menuitem""]');
+    menuItems.forEach(item => {
+        const svgPath = item.querySelector('svg path[d*=""M14.3352 17.5003V15.6654H12.5002""]');
+        if (svgPath) {
+            item.click();
         }
+    });
+}, 800);";
+        }
+
 
         public string GetIsFileAttachedScript()
         {

--- a/ButtonLabelsConfiguration.cs
+++ b/ButtonLabelsConfiguration.cs
@@ -6,10 +6,10 @@ namespace ChatGPTExtension
 {
     public class ButtonLabelsConfiguration
     {
-        public string VSNETToAI { get; set; } = "VS.NET to AI ➡️";
-        public string FixCode { get; set; } = "Fix Code in AI ➡️";
-        public string ImproveCode { get; set; } = "Improve Code in AI ➡️";
-        public string AIToVSNET { get; set; } = "⬅️ AI to VS.NET";
+        public string VSNETToAI { get; set; } = "VS.NET to {AI} ➡️";
+        public string FixCode { get; set; } = "Fix Code in {AI} ➡️";
+        public string ImproveCode { get; set; } = "Improve Code in {AI} ➡️";
+        public string AIToVSNET { get; set; } = "⬅️ {AI} to VS.NET";
         public string ContinueCode { get; set; } = "Continue Code ⏩";
         public string CompleteCode { get; set; } = "Complete Code ✅";
         public string NewFile { get; set; } = "📄 New File";

--- a/ButtonLabelsConfiguration.cs
+++ b/ButtonLabelsConfiguration.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace ChatGPTExtension
+{
+    public class ButtonLabelsConfiguration
+    {
+        public string VSNETToAI { get; set; } = "VS.NET to AI ➡️";
+        public string FixCode { get; set; } = "Fix Code in AI ➡️";
+        public string ImproveCode { get; set; } = "Improve Code in AI ➡️";
+        public string AIToVSNET { get; set; } = "⬅️ AI to VS.NET";
+        public string ContinueCode { get; set; } = "Continue Code ⏩";
+        public string CompleteCode { get; set; } = "Complete Code ✅";
+        public string NewFile { get; set; } = "📄 New File";
+        public string AttachFile { get; set; } = "Attach Current VS File📎";
+        public string EnableCopyCode { get; set; } = "Enable Copy Code";
+
+        private const string FileName = "buttonlabels.json";
+
+        private static readonly string _configPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "ChatGPTExtension", FileName);
+
+        public static ButtonLabelsConfiguration Load()
+        {
+            if (File.Exists(_configPath))
+            {
+                try
+                {
+                    var json = File.ReadAllText(_configPath);
+                    return JsonConvert.DeserializeObject<ButtonLabelsConfiguration>(json) ?? new ButtonLabelsConfiguration();
+                }
+                catch
+                {
+                    return new ButtonLabelsConfiguration();
+                }
+            }
+            return new ButtonLabelsConfiguration();
+        }
+
+        public void Save()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_configPath));
+            var json = JsonConvert.SerializeObject(this, Formatting.Indented);
+            File.WriteAllText(_configPath, json);
+        }
+    }
+}

--- a/ButtonsConfigWindow.xaml
+++ b/ButtonsConfigWindow.xaml
@@ -1,0 +1,57 @@
+<Window x:Class="ChatGPTExtension.ButtonsConfigWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Configure Button Labels" Height="400" Width="400"
+        WindowStartupLocation="CenterScreen"
+        Background="#343541" Foreground="White">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" VerticalAlignment="Top" >
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <Label Content="VS.NET to AI" Width="150" Foreground="White"/>
+                <TextBox x:Name="VSNETToAITxt" Width="200"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <Label Content="Fix Code" Width="150" Foreground="White"/>
+                <TextBox x:Name="FixCodeTxt" Width="200"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <Label Content="Improve Code" Width="150" Foreground="White"/>
+                <TextBox x:Name="ImproveCodeTxt" Width="200"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <Label Content="AI to VS.NET" Width="150" Foreground="White"/>
+                <TextBox x:Name="AIToVSNETTxt" Width="200"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <Label Content="Continue Code" Width="150" Foreground="White"/>
+                <TextBox x:Name="ContinueCodeTxt" Width="200"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <Label Content="Complete Code" Width="150" Foreground="White"/>
+                <TextBox x:Name="CompleteCodeTxt" Width="200"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <Label Content="New File" Width="150" Foreground="White"/>
+                <TextBox x:Name="NewFileTxt" Width="200"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <Label Content="Attach File" Width="150" Foreground="White"/>
+                <TextBox x:Name="AttachFileTxt" Width="200"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,5">
+                <Label Content="Enable Copy Code" Width="150" Foreground="White"/>
+                <TextBox x:Name="EnableCopyCodeTxt" Width="200"/>
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,20,0,0">
+            <Button Content="Save" Width="80" Margin="5" Click="Save_Click"/>
+            <Button Content="Cancel" Width="80" Margin="5" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ButtonsConfigWindow.xaml
+++ b/ButtonsConfigWindow.xaml
@@ -1,9 +1,53 @@
 <Window x:Class="ChatGPTExtension.ButtonsConfigWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Configure Button Labels" Height="400" Width="400"
+        xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+        Title="Configure Button Labels" Height="466" Width="400"
         WindowStartupLocation="CenterScreen"
-        Background="#343541" Foreground="White">
+        Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}" 
+        Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}">
+
+    <Window.Resources>
+        <!-- Style for TextBox -->
+        <Style TargetType="{x:Type TextBox}">
+            <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="5"/>
+            <Setter Property="CaretBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
+        </Style>
+
+        <!-- Style for Button -->
+        <Style TargetType="{x:Type Button}">
+            <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Margin" Value="5"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarHoverOverSelectedKey}}"/>
+                                <Setter Property="Cursor" Value="Hand"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Style for Label -->
+        <Style TargetType="{x:Type Label}">
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
+        </Style>
+    </Window.Resources>
+
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
@@ -12,39 +56,39 @@
 
         <StackPanel Grid.Row="0" VerticalAlignment="Top" >
             <StackPanel Orientation="Horizontal" Margin="0,5">
-                <Label Content="VS.NET to AI" Width="150" Foreground="White"/>
+                <Label Content="VS.NET to AI" Width="150"/>
                 <TextBox x:Name="VSNETToAITxt" Width="200"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,5">
-                <Label Content="Fix Code" Width="150" Foreground="White"/>
+                <Label Content="Fix Code" Width="150"/>
                 <TextBox x:Name="FixCodeTxt" Width="200"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,5">
-                <Label Content="Improve Code" Width="150" Foreground="White"/>
+                <Label Content="Improve Code" Width="150"/>
                 <TextBox x:Name="ImproveCodeTxt" Width="200"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,5">
-                <Label Content="AI to VS.NET" Width="150" Foreground="White"/>
+                <Label Content="AI to VS.NET" Width="150"/>
                 <TextBox x:Name="AIToVSNETTxt" Width="200"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,5">
-                <Label Content="Continue Code" Width="150" Foreground="White"/>
+                <Label Content="Continue Code" Width="150"/>
                 <TextBox x:Name="ContinueCodeTxt" Width="200"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,5">
-                <Label Content="Complete Code" Width="150" Foreground="White"/>
+                <Label Content="Complete Code" Width="150"/>
                 <TextBox x:Name="CompleteCodeTxt" Width="200"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,5">
-                <Label Content="New File" Width="150" Foreground="White"/>
+                <Label Content="New File" Width="150"/>
                 <TextBox x:Name="NewFileTxt" Width="200"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,5">
-                <Label Content="Attach File" Width="150" Foreground="White"/>
+                <Label Content="Attach File" Width="150"/>
                 <TextBox x:Name="AttachFileTxt" Width="200"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,5">
-                <Label Content="Enable Copy Code" Width="150" Foreground="White"/>
+                <Label Content="Enable Copy Code" Width="150"/>
                 <TextBox x:Name="EnableCopyCodeTxt" Width="200"/>
             </StackPanel>
         </StackPanel>

--- a/ButtonsConfigWindow.xaml.cs
+++ b/ButtonsConfigWindow.xaml.cs
@@ -1,0 +1,48 @@
+using System.Windows;
+
+namespace ChatGPTExtension
+{
+    public partial class ButtonsConfigWindow : Window
+    {
+        private readonly ButtonLabelsConfiguration _config;
+        public ButtonsConfigWindow(ButtonLabelsConfiguration config)
+        {
+            InitializeComponent();
+            _config = config;
+            LoadValues();
+        }
+
+        private void LoadValues()
+        {
+            VSNETToAITxt.Text = _config.VSNETToAI;
+            FixCodeTxt.Text = _config.FixCode;
+            ImproveCodeTxt.Text = _config.ImproveCode;
+            AIToVSNETTxt.Text = _config.AIToVSNET;
+            ContinueCodeTxt.Text = _config.ContinueCode;
+            CompleteCodeTxt.Text = _config.CompleteCode;
+            NewFileTxt.Text = _config.NewFile;
+            AttachFileTxt.Text = _config.AttachFile;
+            EnableCopyCodeTxt.Text = _config.EnableCopyCode;
+        }
+
+        private void Save_Click(object sender, RoutedEventArgs e)
+        {
+            _config.VSNETToAI = VSNETToAITxt.Text;
+            _config.FixCode = FixCodeTxt.Text;
+            _config.ImproveCode = ImproveCodeTxt.Text;
+            _config.AIToVSNET = AIToVSNETTxt.Text;
+            _config.ContinueCode = ContinueCodeTxt.Text;
+            _config.CompleteCode = CompleteCodeTxt.Text;
+            _config.NewFile = NewFileTxt.Text;
+            _config.AttachFile = AttachFileTxt.Text;
+            _config.EnableCopyCode = EnableCopyCodeTxt.Text;
+            _config.Save();
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/ChatGPTExtension.csproj
+++ b/ChatGPTExtension.csproj
@@ -72,6 +72,10 @@
     <Compile Include="ChatGPTWindowControl.xaml.cs">
       <DependentUpon>ChatGPTWindowControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ButtonsConfigWindow.xaml.cs">
+      <DependentUpon>ButtonsConfigWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ButtonLabelsConfiguration.cs" />
     <Compile Include="AIConfigurations\ClaudeConfiguration.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="AIConfigurations\GeminiConfiguration.cs" />
@@ -140,6 +144,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="ConfigurationWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="ButtonsConfigWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/ChatGPTWindowControl.xaml
+++ b/ChatGPTWindowControl.xaml
@@ -15,34 +15,19 @@
     <Grid>
         <!-- Define styles for buttons and checkbox -->
         <Grid.Resources>
-            <!--
-                <Setter Property="Background" Value="#343541"/>
-                <Setter Property="Foreground" Value="White"/>
-                <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ButtonBackgroundKey}}"/>
-                ButtonMouseOverBackgroundKey
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
-            -->
-
             <!-- Style for the buttons -->
             <Style TargetType="Button" x:Key="CustomButtonStyle">
-
                 <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"/>
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
                 <Setter Property="Height" Value="26"/>
-                
+
                 <!-- Important Margin -->
                 <Setter Property="Margin" Value="-1,-1,0,0"/>
                 <!-- /Important Margin -->
-                
+
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
-                            <!---
-                            <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1">
-                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                            </Border>
-                            CommandBarMouseOverBackgroundMiddle1Key
-                            -->
                             <Border Background="{TemplateBinding Background}" BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}" BorderThickness="1">
                                 <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Border>
@@ -107,34 +92,61 @@
         <!-- WebView2 Control -->
         <controls:WebView2 Grid.Row="0" Grid.Column="0" Name="webView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5">
-            <Button Name="btnVSNETToAI" Content="VS.NET to GPT ➡️" Click="OnSendCodeButtonClick" Tag="btnVSNETToAI" Style="{StaticResource CustomButtonStyle}"/>
-            <Button Name="btnFixCodeInAI" Content="Fix Code in GPT ➡️" Click="OnSendCodeButtonClick" Tag="Fix {languageCode} code below:" Style="{StaticResource CustomButtonStyle}"/>
-            <Button Name="btnImproveCodeInAI" Content="Improve Code in GPT ➡️" Click="OnSendCodeButtonClick" Tag="Improve {languageCode} code below:" Style="{StaticResource CustomButtonStyle}"/>
-            <Button Name="btnAIToVSNET" Content="⬅️ GPT to VS.NET" Click="OnReceiveCodeButtonClick" Style="{StaticResource CustomButtonStyle}"/>
-            <Button Name="btnContinueCode" Content="Continue Code ⏩" Click="OnContinueCodeButtonClick" Style="{StaticResource CustomButtonStyle}"/>
-            <Button Name="btnCompleteCodeInAI" Content="Complete Code ✅" Click="OnCompleteCodeButtonClick" Style="{StaticResource CustomButtonStyle}"/>
-            <Button Name="btnNewFile" Content="📄 New File" Style="{StaticResource CustomButtonStyle}" Click="OnNewFileButtonClick"/>
-            <Button Name="btnAttachFile" Content="Attach Current VS File📎" Click="OnAttachFileButtonClick" Style="{StaticResource CustomButtonStyle}"/>
-            <Border Background="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}" Margin="0">
-                <CheckBox Style="{StaticResource CustomCheckBoxStyle}" HorizontalAlignment="Center" Name="EnableCopyCodeCheckBox" Click="EnableCopyCodeCheckBox_Click" IsChecked="True" />
-            </Border>
-            <Button Content="▼" Width="26" Style="{StaticResource CustomButtonStyle}">
-                <Button.ContextMenu>
-                    <ContextMenu x:Name="CodeActionsContextMenu" FontSize="15" />
-                </Button.ContextMenu>
-                <Button.Triggers>
-                    <EventTrigger RoutedEvent="Button.Click">
-                        <BeginStoryboard>
-                            <Storyboard>
-                                <BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="ContextMenu.IsOpen">
-                                    <DiscreteBooleanKeyFrame KeyTime="0:0:0" Value="True" />
-                                </BooleanAnimationUsingKeyFrames>
-                            </Storyboard>
-                        </BeginStoryboard>
-                    </EventTrigger>
-                </Button.Triggers>
-            </Button>
-        </StackPanel>
+        <!-- Button Grid with 3 rows -->
+        <Grid Grid.Row="1" Margin="0,5">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <!-- Row 1 -->
+            <Button Grid.Row="0" Grid.Column="0" Name="btnVSNETToAI" Content="VS.NET to Claude ➡️" Click="OnSendCodeButtonClick" Tag="btnVSNETToAI" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Grid.Row="0" Grid.Column="1" Name="btnFixCodeInAI" Content="Fix Code in Claude ➡️" Click="OnSendCodeButtonClick" Tag="Fix {languageCode} code below:" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Grid.Row="0" Grid.Column="2" Name="btnImproveCodeInAI" Content="Improve Code in Claude ➡️" Click="OnSendCodeButtonClick" Tag="Improve {languageCode} code below:" Style="{StaticResource CustomButtonStyle}"/>
+
+            <!-- Row 2 -->
+            <Button Grid.Row="1" Grid.Column="0" Name="btnAIToVSNET" Content="⬅️ Claude to VS.NET" Click="OnReceiveCodeButtonClick" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Grid.Row="1" Grid.Column="1" Name="btnAttachFile" Content="Attach Open File to Claude📎" Click="OnAttachFileButtonClick" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Grid.Row="1" Grid.Column="2" Name="btnCompleteCodeInAI" Content="Complete Code in Claude ✅" Click="OnCompleteCodeButtonClick" Style="{StaticResource CustomButtonStyle}"/>
+
+            <!-- Row 3 -->
+            <Button Grid.Row="2" Grid.Column="0" Name="btnNewFile" Content="📄 New File" Style="{StaticResource CustomButtonStyle}" Click="OnNewFileButtonClick"/>
+            <Button Grid.Row="2" Grid.Column="1" Name="btnContinueCode" Content="Continue Code in Claude ⏩" Click="OnContinueCodeButtonClick" Style="{StaticResource CustomButtonStyle}"/>
+
+            <!-- Row 3 Column 2: Enable Copy Code checkbox and dropdown button -->
+            <Grid Grid.Row="2" Grid.Column="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Border Grid.Column="0" Background="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}" Margin="0">
+                    <CheckBox Style="{StaticResource CustomCheckBoxStyle}" HorizontalAlignment="Center" Name="EnableCopyCodeCheckBox" Click="EnableCopyCodeCheckBox_Click" IsChecked="True" Content="Enable Copy Code" />
+                </Border>
+
+                <Button Grid.Column="1" Content="▼" Width="26" Style="{StaticResource CustomButtonStyle}" Margin="5,0,0,0">
+                    <Button.ContextMenu>
+                        <ContextMenu x:Name="CodeActionsContextMenu" FontSize="15" />
+                    </Button.ContextMenu>
+                    <Button.Triggers>
+                        <EventTrigger RoutedEvent="Button.Click">
+                            <BeginStoryboard>
+                                <Storyboard>
+                                    <BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="ContextMenu.IsOpen">
+                                        <DiscreteBooleanKeyFrame KeyTime="0:0:0" Value="True" />
+                                    </BooleanAnimationUsingKeyFrames>
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </EventTrigger>
+                    </Button.Triggers>
+                </Button>
+            </Grid>
+        </Grid>
     </Grid>
 </UserControl>

--- a/ChatGPTWindowControl.xaml
+++ b/ChatGPTWindowControl.xaml
@@ -81,7 +81,7 @@
                                 </Border>
 
                                 <!-- Text part -->
-                                <TextBlock Grid.Column="1" Text="Enable Copy Code" VerticalAlignment="Center" Margin="10,0,0,0" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
+                                <TextBlock Grid.Column="1" Text="{TemplateBinding Content}" VerticalAlignment="Center" Margin="10,0,0,0" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
@@ -96,68 +96,45 @@
         </Grid.Resources>
 
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
-        <!-- Context Menu Button -->
-        <Button Grid.Row="2" Grid.Column="3" Margin="0,-1,0,0" Content="▼" Height="26" Width="26" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}">
-            <Button.ContextMenu>
-                <ContextMenu x:Name="CodeActionsContextMenu" FontSize="15">
-                </ContextMenu>
-            </Button.ContextMenu>
-            <Button.Triggers>
-                <EventTrigger RoutedEvent="Button.Click">
-                    <BeginStoryboard>
-                        <Storyboard>
-                            <BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="ContextMenu.IsOpen">
-                                <DiscreteBooleanKeyFrame KeyTime="0:0:0" Value="True"/>
-                            </BooleanAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </BeginStoryboard>
-                </EventTrigger>
-            </Button.Triggers>
-        </Button>
-
-        <!-- VS.NET to GPT Button -->
-        <Button Grid.Row="0" Grid.Column="0" Name="btnVSNETToAI" Margin="0,-1,0,0" Content="VS.NET to GPT ➡️" Click="OnSendCodeButtonClick" Tag="btnVSNETToAI" Height="26" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Transfer selected code from VS.NET to GPT"/>
-
-        <!-- Fix Code in GPT Button -->
-        <Button Grid.Row="0" Grid.Column="1" Name="btnFixCodeInAI" Content="Fix Code in GPT ➡️" Click="OnSendCodeButtonClick" Tag="Fix {languageCode} code below:" Height="26" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Transfer selected code from GPT to VS.NET"/>
-
-        <!-- Improve Code in GPT Button -->
-        <Button Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2" Name="btnImproveCodeInAI" Content="Improve Code in GPT ➡️" Click="OnSendCodeButtonClick" Tag="Improve {languageCode} code below:" Height="26" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Refactor selected code from VS.NET in GPT" />
-
-        <!-- GPT to VS.NET Button -->
-        <Button Grid.Row="1" Grid.Column="0" Name="btnAIToVSNET" Margin="0,-1,0,0" Content="⬅️ GPT to VS.NET" Click="OnReceiveCodeButtonClick" Height="26" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Transfer selected code from GPT to VS.NET"/>
-        
-        <!-- New Continue Code Button -->
-        <Button Grid.Row="1" Grid.Column="1" Name="btnContinueCode" Content="Continue Code ⏩" Click="OnContinueCodeButtonClick" Height="26" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Continue code generation"/>
-
-        <!-- Complete Code Button -->
-        <Button Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2" Name="btnCompleteCodeInAI" Content="Complete Code ✅" Click="OnCompleteCodeButtonClick" Height="26" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Ask GPT to provide full complete code"/>
-
-        <!-- New File Button -->
-        <Button Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="1" Name="btnNewFile" Margin="0,-1,0,0" Content="📄 New File" Style="{StaticResource CustomButtonStyle}" Click="OnNewFileButtonClick" ToolTip="Create a new file from GPT content" />
-        
-        <!-- Attach Current File Button -->
-        <Button Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="1" Name="btnAttachFile" Content="Attach Current VS File📎" Click="OnAttachFileButtonClick" Height="26" FontFamily="Segoe UI Emoji" Style="{StaticResource CustomButtonStyle}" ToolTip="Attach currently selected file to AI (hit Enter after file is set in dialog)"/>
-
-        <!-- Enable Copy Code Checkbox -->
-        <Border Grid.Row="2" Grid.Column="2" Background="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}">
-            <CheckBox Style="{StaticResource CustomCheckBoxStyle}" HorizontalAlignment="Center" Name="EnableCopyCodeCheckBox" Click="EnableCopyCodeCheckBox_Click" IsChecked="True" ToolTip="Enable sending code from GPT to VS.NET when Copy code button is clicked in GPT" />
-        </Border>
-
         <!-- WebView2 Control -->
-        <controls:WebView2 Grid.Row="4" Grid.ColumnSpan="4" Name="webView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+        <controls:WebView2 Grid.Row="0" Grid.Column="0" Name="webView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5">
+            <Button Name="btnVSNETToAI" Content="VS.NET to GPT ➡️" Click="OnSendCodeButtonClick" Tag="btnVSNETToAI" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Name="btnFixCodeInAI" Content="Fix Code in GPT ➡️" Click="OnSendCodeButtonClick" Tag="Fix {languageCode} code below:" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Name="btnImproveCodeInAI" Content="Improve Code in GPT ➡️" Click="OnSendCodeButtonClick" Tag="Improve {languageCode} code below:" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Name="btnAIToVSNET" Content="⬅️ GPT to VS.NET" Click="OnReceiveCodeButtonClick" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Name="btnContinueCode" Content="Continue Code ⏩" Click="OnContinueCodeButtonClick" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Name="btnCompleteCodeInAI" Content="Complete Code ✅" Click="OnCompleteCodeButtonClick" Style="{StaticResource CustomButtonStyle}"/>
+            <Button Name="btnNewFile" Content="📄 New File" Style="{StaticResource CustomButtonStyle}" Click="OnNewFileButtonClick"/>
+            <Button Name="btnAttachFile" Content="Attach Current VS File📎" Click="OnAttachFileButtonClick" Style="{StaticResource CustomButtonStyle}"/>
+            <Border Background="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}" Margin="0">
+                <CheckBox Style="{StaticResource CustomCheckBoxStyle}" HorizontalAlignment="Center" Name="EnableCopyCodeCheckBox" Click="EnableCopyCodeCheckBox_Click" IsChecked="True" />
+            </Border>
+            <Button Content="▼" Width="26" Style="{StaticResource CustomButtonStyle}">
+                <Button.ContextMenu>
+                    <ContextMenu x:Name="CodeActionsContextMenu" FontSize="15" />
+                </Button.ContextMenu>
+                <Button.Triggers>
+                    <EventTrigger RoutedEvent="Button.Click">
+                        <BeginStoryboard>
+                            <Storyboard>
+                                <BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="ContextMenu.IsOpen">
+                                    <DiscreteBooleanKeyFrame KeyTime="0:0:0" Value="True" />
+                                </BooleanAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </EventTrigger>
+                </Button.Triggers>
+            </Button>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/ChatGPTWindowControl.xaml.cs
+++ b/ChatGPTWindowControl.xaml.cs
@@ -1174,20 +1174,20 @@ namespace ChatGPTExtension
             string aiTechnology = _aiModelType.ToString();
 
             // Update the content and tooltip for the buttons
-            btnVSNETToAI.Content = _buttonLabels.VSNETToAI.Replace("{ai}", aiTechnology);
+            btnVSNETToAI.Content = _buttonLabels.VSNETToAI.Replace("{AI}", aiTechnology);
             btnVSNETToAI.ToolTip = $"Transfer selected code from VS.NET to {aiTechnology}";
 
-            btnFixCodeInAI.Content = _buttonLabels.FixCode.Replace("{ai}", aiTechnology);
+            btnFixCodeInAI.Content = _buttonLabels.FixCode.Replace("{AI}", aiTechnology);
             btnFixCodeInAI.ToolTip = $"Fix bugs in VS.NET selected code using {aiTechnology}";
 
-            btnImproveCodeInAI.Content = _buttonLabels.ImproveCode.Replace("{ai}", aiTechnology);
+            btnImproveCodeInAI.Content = _buttonLabels.ImproveCode.Replace("{AI}", aiTechnology);
             btnImproveCodeInAI.ToolTip = $"Refactor selected code from VS.NET in {aiTechnology}";
 
 
-            btnAIToVSNET.Content = _buttonLabels.AIToVSNET.Replace("{ai}", aiTechnology);
+            btnAIToVSNET.Content = _buttonLabels.AIToVSNET.Replace("{AI}", aiTechnology);
             btnAIToVSNET.ToolTip = $"Transfer selected code from {aiTechnology} to VS.NET";
 
-            btnAttachFile.Content = _buttonLabels.AttachFile.Replace("{ai}", aiTechnology);
+            btnAttachFile.Content = _buttonLabels.AttachFile.Replace("{AI}", aiTechnology);
             btnAttachFile.ToolTip = $"Attach VS.NET file open to {aiTechnology}";
 
             btnCompleteCodeInAI.Content = _buttonLabels.CompleteCode.Replace("{ai}", aiTechnology);
@@ -1296,11 +1296,8 @@ namespace ChatGPTExtension
                                 }
                                 else if (_aiModelType == AIModelType.GPT)
                                 {
-                                    string clickButtonScript = GPTConfiguration.Instance.GetAttachFileButtonClickScript();
+                                    string clickButtonScript = GPTConfiguration.Instance.GetFileInputClickScript();
                                     await webView.CoreWebView2.ExecuteScriptAsync(clickButtonScript);
-
-                                    string clickMenuItemScript = GPTConfiguration.Instance.GetAttachFileMenuItemClickScript();
-                                    await webView.CoreWebView2.ExecuteScriptAsync(clickMenuItemScript);
                                 }
                                 else if (_aiModelType == AIModelType.DeepSeek)
                                 {

--- a/ChatGPTWindowControl.xaml.cs
+++ b/ChatGPTWindowControl.xaml.cs
@@ -43,6 +43,7 @@ namespace ChatGPTExtension
         private bool _enableCopyCode = true;
         private readonly IServiceProvider _serviceProvider;
         private ConfigurationWindow _configWindow = new ConfigurationWindow();
+        private ButtonLabelsConfiguration _buttonLabels = ButtonLabelsConfiguration.Load();
         private AIModelType _aiModelType = AIModelType.GPT;
         private ChatGPTToolWindow _parentToolWindow;
 
@@ -998,6 +999,15 @@ namespace ChatGPTExtension
             LoadContextMenuActions();
         }
 
+        private void ConfigureLabelsMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            var window = new ButtonsConfigWindow(_buttonLabels);
+            if (window.ShowDialog() == true)
+            {
+                UpdateButtonContentAndTooltip();
+            }
+        }
+
         private void LoadContextMenuActions()
         {
             var actions = _configWindow.ActionItems;
@@ -1035,6 +1045,11 @@ namespace ChatGPTExtension
             var configureMenuItem = new MenuItem { Header = "Configure extension..." };
             configureMenuItem.Click += ConfigureExtensionMenuItem_Click;
             CodeActionsContextMenu.Items.Add(configureMenuItem);
+
+            // Add Configure button labels... menu item
+            var configureLabelsMenuItem = new MenuItem { Header = "Configure button labels..." };
+            configureLabelsMenuItem.Click += ConfigureLabelsMenuItem_Click;
+            CodeActionsContextMenu.Items.Add(configureLabelsMenuItem);
 
             // Add another separator before the new options
             CodeActionsContextMenu.Items.Add(new Separator());
@@ -1159,30 +1174,33 @@ namespace ChatGPTExtension
             string aiTechnology = _aiModelType.ToString();
 
             // Update the content and tooltip for the buttons
-            btnVSNETToAI.Content = $"VS.NET to {aiTechnology} ➡️";
+            btnVSNETToAI.Content = _buttonLabels.VSNETToAI.Replace("{ai}", aiTechnology);
             btnVSNETToAI.ToolTip = $"Transfer selected code from VS.NET to {aiTechnology}";
 
-            btnFixCodeInAI.Content = $"Fix Code in {aiTechnology} ➡️";
+            btnFixCodeInAI.Content = _buttonLabels.FixCode.Replace("{ai}", aiTechnology);
             btnFixCodeInAI.ToolTip = $"Fix bugs in VS.NET selected code using {aiTechnology}";
 
-            btnImproveCodeInAI.Content = $"Improve Code in {aiTechnology} ➡️";
+            btnImproveCodeInAI.Content = _buttonLabels.ImproveCode.Replace("{ai}", aiTechnology);
             btnImproveCodeInAI.ToolTip = $"Refactor selected code from VS.NET in {aiTechnology}";
 
 
-            btnAIToVSNET.Content = $"⬅️ {aiTechnology} to VS.NET";
+            btnAIToVSNET.Content = _buttonLabels.AIToVSNET.Replace("{ai}", aiTechnology);
             btnAIToVSNET.ToolTip = $"Transfer selected code from {aiTechnology} to VS.NET";
 
-            btnAttachFile.Content = $"Attach Open File to {aiTechnology}📎";
+            btnAttachFile.Content = _buttonLabels.AttachFile.Replace("{ai}", aiTechnology);
             btnAttachFile.ToolTip = $"Attach VS.NET file open to {aiTechnology}";
 
-            btnCompleteCodeInAI.Content = $"Complete Code in {aiTechnology} ✅";
+            btnCompleteCodeInAI.Content = _buttonLabels.CompleteCode.Replace("{ai}", aiTechnology);
             btnCompleteCodeInAI.ToolTip = $"Ask {aiTechnology} to generate complete code";
 
 
+            btnNewFile.Content = _buttonLabels.NewFile.Replace("{ai}", aiTechnology);
             btnNewFile.ToolTip = $"Select code in {aiTechnology} to create a new file in VS.NET";
 
-            btnContinueCode.Content = $"Continue Code in {aiTechnology} ⏩";
+            btnContinueCode.Content = _buttonLabels.ContinueCode.Replace("{ai}", aiTechnology);
             btnContinueCode.ToolTip = $"Ask {aiTechnology} to continue the code generation";
+
+            EnableCopyCodeCheckBox.Content = _buttonLabels.EnableCopyCode.Replace("{ai}", aiTechnology);
 
             EnableCopyCodeCheckBox.ToolTip = $"Enable sending code from {aiTechnology} to VS.NET when Copy code button is clicked in {aiTechnology}";
         }

--- a/Configuration.cs
+++ b/Configuration.cs
@@ -14,6 +14,7 @@ namespace ChatGPTExtension
 {
     public class Configuration
     {
-        public int GptConfigured { get; set; }
+        public int GptConfigured { get; set; } = 1; // Default to GPT
+        public bool ButtonsAtTop { get; set; } = false; // Default to bottom
     }
 }

--- a/ConfigurationWindow.xaml
+++ b/ConfigurationWindow.xaml
@@ -2,9 +2,11 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:ChatGPTExtension"
+        xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
         xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="ChatGPTExtension.ConfigurationWindow"
         Title="Chat GPT Extension - Configuration"
-        Foreground="White"
+        Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+        Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
         Height="700"
         Width="900"
         WindowStartupLocation="CenterScreen"
@@ -14,38 +16,58 @@
 
         <!-- Style for TextBox -->
         <Style TargetType="{x:Type TextBox}">
-            <Setter Property="Background" Value="#343541"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
             <Setter Property="Padding" Value="5"/>
             <Setter Property="Margin" Value="0"/>
-            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
             <Setter Property="HorizontalAlignment" Value="Stretch"/>
             <Setter Property="VerticalAlignment" Value="Stretch"/>
-            <Setter Property="CaretBrush" Value="White"/>
-            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="CaretBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
         </Style>
 
         <!-- Style for Button -->
         <Style TargetType="{x:Type Button}">
-            <Setter Property="Background" Value="#343541"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
+            <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Margin" Value="5"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarHoverOverSelectedKey}}"/>
+                                <Setter Property="Cursor" Value="Hand"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
 
         <!-- Style for GridViewColumnHeader -->
         <Style TargetType="{x:Type GridViewColumnHeader}">
-            <Setter Property="Background" Value="#343541"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
         </Style>
 
         <Style TargetType="{x:Type ListViewItem}">
             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
             <Setter Property="VerticalContentAlignment" Value="Stretch"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
         </Style>
 
     </Window.Resources>
 
-    <Grid Background="#343541">
+    <Grid Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}">
         <!-- Define rows in the grid. The first row takes up the majority of space; the second row is for the buttons. -->
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
@@ -55,8 +77,8 @@
         <ListView x:Name="ActionListView" 
           ItemsSource="{Binding Path=DataContext.ActionItems, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" 
           Margin="10"  
-          Background="#343541"
-          Foreground="White">
+          Background="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"
+          Foreground="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}">
 
             <ListView.ItemContainerStyle>
                 <Style TargetType="{x:Type ListViewItem}">
@@ -82,7 +104,7 @@
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <!-- The TextBlock here acts as a "handle" for dragging. -->
-                                <TextBlock Text="≡" FontSize="32" Cursor="SizeAll"  HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" ToolTip="Reorder Action"/>
+                                <TextBlock Text="≡" FontSize="32" Cursor="SizeAll"  HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}" ToolTip="Reorder Action"/>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
@@ -110,7 +132,7 @@
                     <GridViewColumn Width="50">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <Button Content="❌" FontSize="14" Click="DeleteButton_Click" Background="#343541" ToolTip="Delete Action"/>
+                                <Button Content="❌" FontSize="14" Click="DeleteButton_Click" ToolTip="Delete Action"/>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
@@ -120,11 +142,11 @@
 
         <!-- Save and Cancel buttons at the bottom, placed in the second row -->
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,20,0,20" Grid.Row="1">
-            <Button Content="Add Action" Click="AddButton_Click" Background="#343541" Width="100" Foreground="White" Padding="10,5" Margin="5,5,25,5" ToolTip="Add new action" />
+            <Button Content="Add Action" Click="AddButton_Click" Width="100" Padding="10,5" Margin="5,5,25,5" ToolTip="Add new action" />
 
-            <Button x:Name="SaveButton" Content="Save" Click="OnSaveClick" Width="100" Background="#343541" Foreground="White" Padding="10,5" Margin="5" ToolTip="Save all actions" />
-            <Button x:Name="CancelButton" Content="Cancel" Click="OnCancelClick" Width="100" Background="#343541" Foreground="White" Padding="10,5" Margin="5" ToolTip="Cancel changes" />
-            <Button x:Name="ConfigureGPTWideButton" Content="GPT Wide" Click="ConfigureGPTWideButton_Click"  Width="100" Background="#343541" Foreground="White" Padding="10,5" Margin="25,5,5,5" ToolTip="Configure GPT Wide" />
+            <Button x:Name="SaveButton" Content="Save" Click="OnSaveClick" Width="100" Padding="10,5" Margin="5" ToolTip="Save all actions" />
+            <Button x:Name="CancelButton" Content="Cancel" Click="OnCancelClick" Width="100" Padding="10,5" Margin="5" ToolTip="Cancel changes" />
+            <Button x:Name="ConfigureGPTWideButton" Content="GPT Wide" Click="ConfigureGPTWideButton_Click"  Width="100" Padding="10,5" Margin="25,5,5,5" ToolTip="Configure GPT Wide" />
         </StackPanel>
     </Grid>
 </Window>

--- a/GPTWideWindow.xaml
+++ b/GPTWideWindow.xaml
@@ -1,36 +1,62 @@
 ﻿<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
         xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="ChatGPTExtension.GPTWideWindow"
         Title="Script Configuration - Wide GPT Responses"
         Height="700"
         Width="900"
         WindowStartupLocation="CenterScreen"
-        Background="#343541"
-        Foreground="White"
+        Background="{DynamicResource {x:Static vsshell:VsBrushes.WindowKey}}"
+        Foreground="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"
         Loaded="Window_Loaded">
-
 
     <Window.Resources>
         <!-- Style for TextBox -->
         <Style TargetType="{x:Type TextBox}">
-            <Setter Property="Background" Value="#343541"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
             <Setter Property="Padding" Value="5"/>
             <Setter Property="Margin" Value="0"/>
-            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="HorizontalAlignment" Value="Stretch"/>
             <Setter Property="VerticalAlignment" Value="Stretch"/>
-            <Setter Property="CaretBrush" Value="White"/>
-            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="CaretBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
         </Style>
 
         <!-- Style for Button -->
         <Style TargetType="{x:Type Button}">
-            <Setter Property="Background" Value="#343541"/>
-            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBackgroundKey}}"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"/>
+            <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Margin" Value="5"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarHoverOverSelectedKey}}"/>
+                                <Setter Property="Cursor" Value="Hand"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
 
+        <!-- Style for Label -->
+        <Style TargetType="{x:Type Label}">
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.WindowTextKey}}"/>
+        </Style>
+
+        <!-- Style for Hyperlink -->
+        <Style TargetType="{x:Type Hyperlink}">
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
+        </Style>
     </Window.Resources>
 
     <Grid>
@@ -45,26 +71,25 @@
         </Grid.RowDefinitions>
 
         <!-- Label at the top -->
-        <Label Grid.Row="0" Foreground="White" Padding="10" HorizontalAlignment="Center">
+        <Label Grid.Row="0" Padding="10" HorizontalAlignment="Center">
             <TextBlock TextWrapping="Wrap">
         This is the script to wide GPT responses for wide screen monitors (code is not validated). Delete script to disable it.<LineBreak/><LineBreak/>
-        This script is from <Hyperlink Foreground="LightYellow" NavigateUri="https://gist.github.com/alexchexes/d2ff0b9137aa3ac9de8b0448138125ce" RequestNavigate="Hyperlink_RequestNavigate">https://gist.github.com/alexchexes/d2ff0b9137aa3ac9de8b0448138125ce</Hyperlink>
+        This script is from <Hyperlink NavigateUri="https://gist.github.com/alexchexes/d2ff0b9137aa3ac9de8b0448138125ce" RequestNavigate="Hyperlink_RequestNavigate">https://gist.github.com/alexchexes/d2ff0b9137aa3ac9de8b0448138125ce</Hyperlink>
             </TextBlock>
         </Label>
 
         <!-- Large TextArea -->
-        <TextBox Grid.Row="1" Style="{StaticResource {x:Type TextBox}}"
+        <TextBox Grid.Row="1"
                  x:Name="txtScriptGPTWide"
                  AcceptsReturn="True" AcceptsTab="True"
                  TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
                  Margin="10"
-                 BorderThickness="1"
                  />
 
         <!-- Save and Cancel buttons at the bottom -->
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="2" Margin="0,20">
-            <Button Content="Save" Width="100" Style="{StaticResource {x:Type Button}}" Margin="5" Click="SaveButton_Click"/>
-            <Button Content="Cancel" Width="100" Style="{StaticResource {x:Type Button}}" Margin="5" Click="CancelButton_Click"/>
+            <Button Content="Save" Width="100" Margin="5" Click="SaveButton_Click"/>
+            <Button Content="Cancel" Width="100" Margin="5" Click="CancelButton_Click"/>
         </StackPanel>
     </Grid>
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.3.0.0")]
-[assembly: AssemblyFileVersion("6.3.0.0")]
+[assembly: AssemblyVersion("7.0.0.0")]
+[assembly: AssemblyFileVersion("7.0.0.0")]

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ChatGPTExtension.b5d7cf4a-65ad-4f6b-8f5a-5d27c2a5d4e2" Version="6.3" Language="en-US" Publisher="Daniel Carvalho Liedke" />
+        <Identity Id="ChatGPTExtension.b5d7cf4a-65ad-4f6b-8f5a-5d27c2a5d4e2" Version="7.0" Language="en-US" Publisher="Daniel Carvalho Liedke" />
         <DisplayName>ChatGPTExtension</DisplayName>
         <Description xml:space="preserve">Chat GPT extension will load Open AI Chat GPT web and integrate with Visual Studio.
 Google Gemini, Anthropic Claude AI and Hangzhou Deepseek also supported.</Description>


### PR DESCRIPTION
## Summary
- add `ButtonsConfigWindow` for editing button labels
- store button label settings via new `ButtonLabelsConfiguration`
- show bottom button controls in a horizontal panel
- expose menu item to configure labels
- support customizing Enable Copy Code label

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild /t:Restore,Build /p:Configuration=Release ChatGPTExtension.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615ffc380c832aa0264f22f8d50c98