### PR TITLE
Fix the Clause Code copy button

### DIFF
--- a/AIConfigurations/ClaudeConfiguration.cs
+++ b/AIConfigurations/ClaudeConfiguration.cs
@@ -51,7 +51,7 @@ namespace ChatGPTExtension
         public const string CLAUDE_URL = "https://claude.ai/chats";
         public const string CLAUDE_PROMPT_CLASS = "ProseMirror";
         public const string CLAUDE_COPY_CODE_BUTTON_TEXT = "Copy";
-        public const string CLAUDE_PROJECT_COPY_CODE_BUTTON_SELECTOR = "button.inline-flex[data-state=\"closed\"] svg path[d=\"M200,32H163.74a47.92,47.92,0,0,0-71.48,0H56A16,16,0,0,0,40,48V216a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V48A16,16,0,0,0,200,32Zm-72,0a32,32,0,0,1,32,32H96A32,32,0,0,1,128,32Zm72,184H56V48H82.75A47.93,47.93,0,0,0,80,64v8a8,8,0,0,0,8,8h80a8,8,0,0,0,8-8V64a47.93,47.93,0,0,0-2.75-16H200Z\"]";
+        public const string CLAUDE_PROJECT_COPY_CODE_BUTTON_SELECTOR = "button.inline-flex[data-state='closed'][aria-label='Copy to clipboard'] svg, div[role='menuitem']:has-text('Copy')";
 
         public string GetSetPromptScript(string promptText)
         {

--- a/ai-config.json
+++ b/ai-config.json
@@ -15,7 +15,7 @@
     "Url": "https://claude.ai/chats",
     "PromptClass": "ProseMirror",
     "CopyCodeButtonSelector": "button[data-state=\"closed\"] svg[viewBox=\"0 0 20 20\"] path[d^=\"M10 1.5C11.1097\"]",
-    "ProjectCopyCodeButtonSelector": "button.inline-flex[data-state=\"closed\"] svg path[d=\"M200,32H163.74a47.92,47.92,0,0,0-71.48,0H56A16,16,0,0,0,40,48V216a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V48A16,16,0,0,0,200,32Zm-72,0a32,32,0,0,1,32,32H96A32,32,0,0,1,128,32Zm72,184H56V48H82.75A47.93,47.93,0,0,0,80,64v8a8,8,0,0,0,8,8h80a8,8,0,0,0,8-8V64a47.93,47.93,0,0,0-2.75-16H200Z\"]",
+    "ProjectCopyCodeButtonSelector": "button.inline-flex[data-state='closed'][aria-label='Copy to clipboard'] svg, div[role='menuitem']:has-text('Copy')",
     "SendButtonSelector": "button.inline-flex[aria-label*=\"message\"]"
   },
     "DeepSeek": {


### PR DESCRIPTION
Fix the Clause Code copy button. The Path has changed resulting in the selector failing to register the button click. Made it less specific while also adding support for the copy button on Claude Code Artifacts.